### PR TITLE
Fix curve approximate accuracy and precision

### DIFF
--- a/src/render/hw/hw_geometry_raster.hpp
+++ b/src/render/hw/hw_geometry_raster.hpp
@@ -52,6 +52,8 @@ class HWGeometryRaster {
   Paint::Cap LineCap() const { return paint_.getStrokeCap(); }
   Paint::Join LineJoin() const { return paint_.getStrokeJoin(); }
 
+  void ChangeLineJoin(Paint::Join join) { paint_.setStrokeJoin(join); }
+
   void HandleLineCap(glm::vec2 const& center, glm::vec2 const& p0,
                      glm::vec2 const& p1, glm::vec2 const& out_dir,
                      float stroke_radius);

--- a/src/render/hw/hw_path_raster.cc
+++ b/src/render/hw/hw_path_raster.cc
@@ -176,6 +176,8 @@ void HWPathRaster::HandleLineJoin(glm::vec2 const& p1, glm::vec2 const& p2,
     curr_join = p1 + current_normal * stroke_radius;
   }
 
+  float delta = glm::length(prev_join - curr_join);
+
   switch (LineJoin()) {
     case Paint::kMiter_Join:
       HandleMiterJoinInternal(p1, prev_join, prev_dir, curr_join, -curr_dir);
@@ -185,7 +187,12 @@ void HWPathRaster::HandleLineJoin(glm::vec2 const& p1, glm::vec2 const& p2,
                               glm::normalize(prev_dir - curr_dir));
       break;
     case Paint::kRound_Join:
-      HandleRoundJoinInternal(p1, prev_join, prev_dir, curr_join, curr_dir);
+      if (delta < 1.f) {
+        HandleBevelJoinInternal(p1, prev_join, curr_join,
+                                glm::normalize(prev_dir - curr_dir));
+      } else {
+        HandleRoundJoinInternal(p1, prev_join, prev_dir, curr_join, curr_dir);
+      }
       break;
     default:
       break;

--- a/src/render/hw/hw_path_visitor.cc
+++ b/src/render/hw/hw_path_visitor.cc
@@ -6,6 +6,8 @@
 
 namespace skity {
 
+#define QUAD_BEVEL_LIMIT 0.01f
+
 static void split_cubic(glm::vec2* base) {
   glm::vec2 a, b, c;
 
@@ -87,6 +89,9 @@ void HWPathVisitor::HandleLineTo(const glm::vec2& p1, const glm::vec2& p2) {
 
 void HWPathVisitor::HandleQuadTo(const glm::vec2& p1, const glm::vec2& p2,
                                  const glm::vec2& p3) {
+  auto saved_join = LineJoin();
+  ChangeLineJoin(Paint::kRound_Join);
+
   std::array<glm::vec2, 33 * 3 + 1> bez_stack{};
   std::array<int32_t, 33> level_stack{};
 
@@ -112,7 +117,7 @@ void HWPathVisitor::HandleQuadTo(const glm::vec2& p1, const glm::vec2& p2,
     d = glm::min(delta.x, delta.y);
   }
 
-  if (d < 0.25f) {
+  if (d < QUAD_BEVEL_LIMIT) {
     goto Draw;
   }
 
@@ -120,7 +125,7 @@ void HWPathVisitor::HandleQuadTo(const glm::vec2& p1, const glm::vec2& p2,
   do {
     d = d / 4.f;
     level++;
-  } while (d > 0.25f);
+  } while (d > QUAD_BEVEL_LIMIT);
 
   levels[0] = level;
   do {
@@ -137,6 +142,8 @@ void HWPathVisitor::HandleQuadTo(const glm::vec2& p1, const glm::vec2& p2,
     top--;
     arc -= 2;
   } while (top >= 0);
+
+  ChangeLineJoin(saved_join);
 }
 
 void HWPathVisitor::HandleConicTo(glm::vec2 const& p1, glm::vec2 const& p2,


### PR DESCRIPTION
this can fix #27 

* always uss round join to handle curve approximate
* improve quad curve approximate accuracy
* fall back to bevel join if two outer point is too close

